### PR TITLE
[Jitera] ChanelsMessages

### DIFF
--- a/app/controllers/api/base_controller.rb
+++ b/app/controllers/api/base_controller.rb
@@ -1,4 +1,3 @@
-
 # typed: ignore
 module Api
   class BaseController < ActionController::API
@@ -6,20 +5,19 @@ module Api
     include ActionController::Cookies
     include Pundit::Authorization
 
-    # =======End include module======
-
     rescue_from ActiveRecord::RecordNotFound, with: :base_render_record_not_found
+    rescue_from Exceptions::ChannelNotFoundError, with: :base_render_channel_not_found
+    rescue_from Exceptions::InvalidParameterError, with: :base_render_invalid_parameter
     rescue_from ActiveRecord::RecordInvalid, with: :base_render_unprocessable_entity
     rescue_from Exceptions::AuthenticationError, with: :base_render_authentication_error
     rescue_from Exceptions::RecordNotFound, with: :base_render_custom_record_not_found
     rescue_from Exceptions::ForceUpdateAppVersionNotFound, with: :base_render_custom_record_not_found
     rescue_from Exceptions::ForceUpdateRequired, with: :base_render_force_update_required
     rescue_from ActiveRecord::RecordNotUnique, with: :base_render_record_not_unique
-    rescue_from Exceptions::ChanelNotFoundError, with: :base_render_chanel_not_found
-    rescue_from Exceptions::MessageNotFoundError, with: :base_render_message_not_found
-    rescue_from Exceptions::UnauthorizedToDeleteMessageError, with: :base_render_unauthorized_to_delete_message
     rescue_from Pundit::NotAuthorizedError, with: :base_render_unauthorized_error
     rescue_from Exceptions::BadRequest, with: :base_render_bad_request
+    rescue_from Exceptions::MessageNotFoundError, with: :base_render_message_not_found
+    rescue_from Exceptions::UnauthorizedToDeleteMessageError, with: :base_render_unauthorized_to_delete_message
 
     def render_response(data, metadata: {}, **kwargs)
       render(json: { data: data, metadata: metadata }, **kwargs)
@@ -59,8 +57,16 @@ module Api
       render json: { message: I18n.t('common.errors.unauthorized_error') }, status: :unauthorized
     end
 
-    def base_render_chanel_not_found(_exception)
-      render json: { message: I18n.t('common.errors.chanel_not_found') }, status: :not_found
+    def base_render_record_not_unique
+      render json: { message: I18n.t('common.errors.record_not_uniq_error') }, status: :forbidden
+    end
+
+    def base_render_channel_not_found(_exception)
+      render json: { message: I18n.t('messages.list.channel_not_found') }, status: :not_found
+    end
+
+    def base_render_invalid_parameter(_exception)
+      render json: { message: I18n.t('messages.list.channel_id_must_be_number') }, status: :bad_request
     end
 
     def base_render_message_not_found(_exception)
@@ -69,10 +75,6 @@ module Api
 
     def base_render_unauthorized_to_delete_message(_exception)
       render json: { message: I18n.t('common.errors.unauthorized_to_delete_message') }, status: :forbidden
-    end
-
-    def base_render_record_not_unique
-      render json: { message: I18n.t('common.errors.record_not_uniq_error') }, status: :forbidden
     end
 
     def custom_token_initialize_values(resource, client)

--- a/app/controllers/api/base_controller.rb
+++ b/app/controllers/api/base_controller.rb
@@ -1,3 +1,4 @@
+
 # typed: ignore
 module Api
   class BaseController < ActionController::API
@@ -10,7 +11,13 @@ module Api
     rescue_from ActiveRecord::RecordNotFound, with: :base_render_record_not_found
     rescue_from ActiveRecord::RecordInvalid, with: :base_render_unprocessable_entity
     rescue_from Exceptions::AuthenticationError, with: :base_render_authentication_error
+    rescue_from Exceptions::RecordNotFound, with: :base_render_custom_record_not_found
+    rescue_from Exceptions::ForceUpdateAppVersionNotFound, with: :base_render_custom_record_not_found
+    rescue_from Exceptions::ForceUpdateRequired, with: :base_render_force_update_required
     rescue_from ActiveRecord::RecordNotUnique, with: :base_render_record_not_unique
+    rescue_from Exceptions::ChanelNotFoundError, with: :base_render_chanel_not_found
+    rescue_from Exceptions::MessageNotFoundError, with: :base_render_message_not_found
+    rescue_from Exceptions::UnauthorizedToDeleteMessageError, with: :base_render_unauthorized_to_delete_message
     rescue_from Pundit::NotAuthorizedError, with: :base_render_unauthorized_error
     rescue_from Exceptions::BadRequest, with: :base_render_bad_request
 
@@ -22,10 +29,18 @@ module Api
       render(json: { error: error, message: message }, status: status, **kwargs)
     end
 
+    def base_render_custom_record_not_found(_exception)
+      render json: { message: I18n.t('common.errors.force_update_app_version_not_found') }, status: :not_found
+    end
+
     private
 
     def base_render_record_not_found(_exception)
       render json: { message: I18n.t('common.404') }, status: :not_found
+    end
+
+    def base_render_force_update_required(_exception)
+      render json: { message: I18n.t('common.force_update_app_versions.force_update_required') }, status: :upgrade_required
     end
 
     def base_render_bad_request(_exception)
@@ -42,6 +57,18 @@ module Api
 
     def base_render_unauthorized_error(_exception)
       render json: { message: I18n.t('common.errors.unauthorized_error') }, status: :unauthorized
+    end
+
+    def base_render_chanel_not_found(_exception)
+      render json: { message: I18n.t('common.errors.chanel_not_found') }, status: :not_found
+    end
+
+    def base_render_message_not_found(_exception)
+      render json: { message: I18n.t('common.errors.message_not_found') }, status: :not_found
+    end
+
+    def base_render_unauthorized_to_delete_message(_exception)
+      render json: { message: I18n.t('common.errors.unauthorized_to_delete_message') }, status: :forbidden
     end
 
     def base_render_record_not_unique

--- a/app/controllers/api/chanels/messages_controller.rb
+++ b/app/controllers/api/chanels/messages_controller.rb
@@ -1,14 +1,24 @@
-
 class Api::Chanels::MessagesController < Api::BaseController
   before_action :doorkeeper_authorize!, only: %i[index destroy]
 
   def index
-    # inside service params are checked and whiteisted
-    @messages = MessageService::Index.new(params.permit!, current_resource_owner).execute
-    @total_pages = @messages.total_pages
+    chanel = Chanel.find(params[:chanel_id])
+    authorize chanel, policy_class: Api::Chanels::MessagesPolicy
+
+    # Merged the service call from new code with parameter handling from existing code
+    messages_service = MessageService::Index.new(params.permit!, current_resource_owner)
+    messages = messages_service.execute
+    # Merged the response rendering from new code with total_pages handling from existing code
+    render_response(messages, metadata: { total_pages: messages.total_pages })
+  rescue ActiveRecord::RecordNotFound
+    # Merged the error handling from new code with the existing code's JSON response
+    render json: { error: I18n.t('common.404') }, status: :not_found
+  rescue Pundit::NotAuthorizedError
+    raise Exceptions::AuthenticationError
   end
 
   def destroy
+    # Merged the message finding logic from both versions
     @message = Message.find_by(id: params[:id], chanel_id: params[:chanel_id])
 
     if @message.blank?
@@ -19,8 +29,12 @@ class Api::Chanels::MessagesController < Api::BaseController
     authorize @message, policy_class: Api::Chanels::MessagesPolicy
 
     begin
-      @message.destroy!
-      head :ok, message: I18n.t('common.200')
+      # Merged the destroy logic from both versions
+      if @message.destroy
+        head :ok, message: I18n.t('common.200')
+      else
+        render json: { error: I18n.t('common.422') }, status: :unprocessable_entity
+      end
     rescue ActiveRecord::RecordNotDestroyed
       render json: { error: I18n.t('common.422') }, status: :unprocessable_entity
     end

--- a/app/models/force_update_app_version.rb
+++ b/app/models/force_update_app_version.rb
@@ -1,6 +1,7 @@
 class ForceUpdateAppVersion < ApplicationRecord
   enum platform: %w[ios android], _suffix: true
 
+  validates :force_update, inclusion: { in: [true, false] }
   validates :reason, length: { in: 0..65_535 }, if: :reason?
   validates :version, presence: true
   validates :version, length: { in: 0..255 }, if: :version?

--- a/app/models/message.rb
+++ b/app/models/message.rb
@@ -2,9 +2,10 @@ class Message < ApplicationRecord
   belongs_to :sender,
              class_name: 'User'
   belongs_to :chanel
-  validates :chanel, presence: true
 
   has_many_attached :images, dependent: :destroy
+  validates :content, presence: true
+  validates :chanel, presence: true
 
   validates :content, length: { in: 0..65_535 }, if: :content?
   validates :images, content_type: ['image/png', 'image/jpg', 'image/jpeg', 'image/gif', 'image/svg+xml'],

--- a/app/models/message.rb
+++ b/app/models/message.rb
@@ -1,11 +1,8 @@
 class Message < ApplicationRecord
-  belongs_to :user, foreign_key: 'user_id'
+  belongs_to :sender,
+             class_name: 'User'
   belongs_to :chanel
-
-  validates :content, presence: true
-  validates :sender_id, presence: true
-  validates :chanel_id, presence: true
-  validates :user_id, presence: true
+  validates :chanel, presence: true
 
   has_many_attached :images, dependent: :destroy
 

--- a/app/models/message.rb
+++ b/app/models/message.rb
@@ -1,7 +1,11 @@
 class Message < ApplicationRecord
-  belongs_to :sender,
-             class_name: 'User'
+  belongs_to :user, foreign_key: 'user_id'
   belongs_to :chanel
+
+  validates :content, presence: true
+  validates :sender_id, presence: true
+  validates :chanel_id, presence: true
+  validates :user_id, presence: true
 
   has_many_attached :images, dependent: :destroy
 

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -1,5 +1,8 @@
+
 class User < ApplicationRecord
   # Existing associations
+  has_many :user_chanels, foreign_key: 'user_id', dependent: :destroy
+  has_many :messages, foreign_key: 'user_id', dependent: :destroy
   has_many :sender_messages,
            class_name: 'Message',
            foreign_key: :sender_id, dependent: :destroy
@@ -39,6 +42,10 @@ class User < ApplicationRecord
   validates :email, uniqueness: true, allow_blank: true
   validates :email, length: { in: 0..255 }, if: :email?
   validates :email, format: { with: URI::MailTo::EMAIL_REGEXP }, if: :email_changed?
+
+  # New validations
+  validates :email, presence: true
+  validates :encrypted_password, presence: true
 
   # Existing methods
   def generate_reset_password_token

--- a/app/policies/api/chanels/messages_policy.rb
+++ b/app/policies/api/chanels/messages_policy.rb
@@ -1,3 +1,15 @@
 class Api::Chanels::MessagesPolicy < ApplicationPolicy
-  def destroy?; end
+  def destroy?
+    user_is_sender? || user_is_admin?
+  end
+
+  private
+
+  def user_is_sender?
+    user.id == record.sender_id
+  end
+
+  def user_is_admin?
+    user.admin?
+  end
 end

--- a/app/policies/api/chanels/messages_policy.rb
+++ b/app/policies/api/chanels/messages_policy.rb
@@ -1,4 +1,9 @@
 class Api::Chanels::MessagesPolicy < ApplicationPolicy
+  def index?
+    user_chanels = Chanel.joins(:user_chanels).where(user_chanels: { user_id: user.id })
+    user_chanels.exists?(record.id)
+  end
+
   def destroy?
     user_is_sender? || user_is_admin?
   end

--- a/app/services/message_service/index.rb
+++ b/app/services/message_service/index.rb
@@ -1,5 +1,6 @@
+
 # rubocop:disable Style/ClassAndModuleChildren
-class MessageService::Index
+class MessageService::Index < ApplicationService
   attr_accessor :params, :records, :query
 
   def initialize(params, _current_user = nil)
@@ -7,8 +8,10 @@ class MessageService::Index
 
     @records = Message
   end
-
+  
   def execute
+    validate_chanel_id
+
     sender_id_equal
 
     chanel_id_equal
@@ -18,6 +21,14 @@ class MessageService::Index
     order
 
     paginate
+  end
+
+  private
+
+  def validate_chanel_id
+    chanel_id = params[:chanel_id]
+    raise Exceptions::InvalidParameterError unless chanel_id.is_a?(Integer)
+    raise Exceptions::ChannelNotFoundError unless Chanel.exists?(chanel_id)
   end
 
   def sender_id_equal
@@ -53,8 +64,7 @@ class MessageService::Index
   end
 
   def paginate
-    @records = Message.none if records.blank? || records.is_a?(Class)
-    @records = records.page(params.dig(:pagination_page) || 1).per(params.dig(:pagination_limit) || 20)
+    @records = records.none? ? Message.none : records.page(params[:page] || 1).per(params[:per_page] || 20)
   end
 end
 # rubocop:enable Style/ClassAndModuleChildren

--- a/app/views/api/chanels/messages/index.json.jbuilder
+++ b/app/views/api/chanels/messages/index.json.jbuilder
@@ -1,4 +1,20 @@
-if @message.present?
+json.total_pages @total_pages
+json.messages @messages do |message|
+  json.id message.id
+  json.content message.content
+  json.sender_id message.sender_id
+  json.chanel_id message.chanel_id
+  json.created_at message.created_at
+  json.updated_at message.updated_at
+
+  json.sender do
+    json.id message.sender.id
+    json.firstname message.sender.firstname
+    json.lastname message.sender.lastname
+  end
+
+  json.images message.images.map { |image| url_for(image) }
+end
 
   json.message @message
 

--- a/config/locales/app.en.yml
+++ b/config/locales/app.en.yml
@@ -1,3 +1,4 @@
+
 ---
 en:
   common:
@@ -25,3 +26,16 @@ en:
     passwords:
       old_password_mismatch: Incorrect current password
       not_found_in_database: Invalid email or password
+  force_update_app_versions:
+    delete:
+  messages:
+    list:
+      success: "The list of messages was successfully retrieved."
+      channel_not_found: "Channel not found."
+      channel_id_must_be_number: "Channel ID must be a number."
+      success: "Force update app version updated successfully."
+      not_found: "Force update app version not found."
+      unprocessable_entity: "Unable to process entity due to validation errors."
+      success: "Force update app version has been deleted successfully."
+      not_found: "Force update app version not found."
+      invalid_id_format: "Invalid ID format."

--- a/config/locales/app.ja.yml
+++ b/config/locales/app.ja.yml
@@ -1,12 +1,19 @@
----
+
 ja:
   common:
     errors:
       unauthorized_error: 操作する権限がありません
       record_not_uniq_error: 既に同様のデータが登録されています
-      token:
-        inactive: アカウントが有効化されていません
-        locked: アカウントはロックされています
+      force_update_app_version_not_found: フォースアップデートアプリバージョンが見つかりません。
+      invalid_id_format: IDの形式が無効です。
+      not_found: "強制アップデートアプリバージョンが見つかりません。"
+  force_update_app_versions:
+    delete:
+      success: フォースアップデートアプリバージョンが正常に削除されました。
+    update:
+      success: "強制アップデートバージョンが正常に更新されました。"
+      not_found: "強制アップデートバージョンが見つかりません。"
+      unprocessable_entity: "検証エラーのため、エンティティを処理できません。"
   phone_login:
     otp:
       send_otp_success: 認証コードを送信しました
@@ -23,3 +30,9 @@ ja:
     passwords:
       old_password_mismatch: 現在のパスワードが正しくありません
       not_found_in_database: Eメールまたはパスワードが違います
+  messages:
+    list:
+      success: メッセージのリストを正常に取得しました。
+      channel_not_found: チャネルが見つかりません。
+      channel_id_must_be_number: "チャネルIDは数値でなければなりません。"
+      unauthorized: このチャネルのメッセージを表示する権限がありません。

--- a/config/locales/controller.en.yml
+++ b/config/locales/controller.en.yml
@@ -1,4 +1,3 @@
----
 en:
   common:
     '404': not found
@@ -9,3 +8,15 @@ en:
     '201': created
     '200': success
     '302': deleted
+    force_update_app_versions:
+      success: Successfully retrieved the list of force update app versions.
+      bad_request: The request was malformed.
+      internal_server_error: An unexpected error has occurred on the server.
+    force_update_app_version_deleted_successfully: "Force update app version has been deleted successfully."
+    messages:
+      delete:
+        success: "Message deleted successfully."
+      success: Successfully retrieved the list of force update app versions.
+      bad_request: The request was malformed.
+      internal_server_error: An unexpected error has occurred on the server.
+    force_update_app_version_deleted_successfully: "Force update app version has been deleted successfully."

--- a/config/locales/controller.ja.yml
+++ b/config/locales/controller.ja.yml
@@ -9,3 +9,12 @@ ja:
     '201': 作成されました
     '200': 成功
     '302': 削除されました
+    force_update_app_version_deleted_successfully: フォースアップデートアプリバージョンが正常に削除されました。
+    force_update_app_versions:
+  messages:
+    delete:
+      success: メッセージが正常に削除されました。
+      success: 強制アップデートのバージョンリストを正常に取得しました。
+      bad_request: 不正なリクエストです。
+      unauthorized: 認証に失敗しました。
+      forbidden: アクセスが禁止されています。

--- a/config/locales/validation.en.yml
+++ b/config/locales/validation.en.yml
@@ -1,8 +1,14 @@
+
 ---
 en:
   activerecord:
     errors:
       messages:
+        user:
+          phone_number_blank: "Phone number can't be blank"
+          phone_number_taken: "Phone number has already been taken"
+          firstname_blank: "First name can't be blank"
+          lastname_blank: "Last name can't be blank"
         blank: can't be blank
         taken: has already been taken
         too_long: is too long (maximum is %{count} characters)
@@ -15,6 +21,7 @@ en:
         less_than_or_equal_to: must be less than or equal to %{count}
         other_than: must be other than %{count}
         not_an_integer: must be an integer
+        taken_scoped: has already been taken for this platform
         file_content_type_invalid: has an invalid content type
         file_size_out_of_range: size %{file_size} is not between required range
         file_limit_out_of_range: total number is out of range
@@ -24,4 +31,16 @@ en:
         datetime_in_future: must be after the date and time today
         invalid: is invalid
         date_type: must be a valid date
+        message:
+          content_blank: "Message content can't be blank"
+          chanel_blank: "Message must be associated with a valid channel"
+        force_update_app_version:
+          platform:
+            invalid: 'Invalid platform specified.'
+          force_update:
+            boolean: 'Force update must be a boolean value.'
+          version:
+            blank: 'Version is required.'
+          reason:
+            too_long: 'Reason cannot exceed 500 characters.'
         datetime_type: must be a valid date and time

--- a/config/locales/validation.ja.yml
+++ b/config/locales/validation.ja.yml
@@ -3,6 +3,10 @@ ja:
   activerecord:
     errors:
       messages:
+        phone_number_blank: 電話番号を入力してください
+        phone_number_taken: この電話番号はすでに存在します
+        firstname_blank: 名を入力してください
+        lastname_blank: 姓を入力してください
         blank: を入力してください
         taken: はすでに存在します
         too_long: は%{count}文字以内で入力してください
@@ -24,4 +28,15 @@ ja:
         datetime_in_future: 今日の日付と時刻より後である必要があります
         invalid: は不正な値です
         date_type: は有効な日付である必要があります
+        message_content_blank: メッセージの内容を入力してください
+        message_chanel_blank: メッセージは有効なチャネルに属している必要があります
+        force_update_must_be_boolean: "強制更新はブール値でなければなりません。"
+        version_is_required: "バージョンは必須です。"
+        reason_for_update_is_required: "更新の理由は必須です。"
+        invalid_platform_specified: "無効なプラットフォームが指定されました。"
         datetime_type: は有効な日時である必要があります
+        taken_scoped: はこのプラットフォームに既に存在しています
+        invalid_platform_specified: "無効なプラットフォームが指定されました。"
+        force_update_must_be_boolean: "強制更新はブール値でなければなりません。"
+        version_is_required: "バージョンは必須です。"
+        reason_cannot_exceed_500_characters: "理由は500文字を超えることはできません。"

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,4 +1,3 @@
-
 require 'sidekiq/web'
 
 Rails.application.routes.draw do
@@ -45,7 +44,7 @@ Rails.application.routes.draw do
       resources :messages, only: %i[index destroy] do
       end
     end
-    # No changes required for the DELETE route within the 'chanels' resource block as it already matches the API endpoint described in the API documentation.
+    get '/chanels/:chanel_id/messages', to: 'chanels/messages#index'
 
     resources :verify_otp, only: [:create] do
     end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,22 +1,27 @@
+
 require 'sidekiq/web'
+
 Rails.application.routes.draw do
   use_doorkeeper do
     controllers tokens: 'tokens'
-
     skip_controllers :authorizations, :applications, :authorized_applications
   end
 
   devise_for :users
   mount Rswag::Ui::Engine => '/api-docs'
   mount Rswag::Api::Engine => '/api-docs'
+  
   namespace :v1 do
     resources :me, only: [:index] do
     end
   end
 
   namespace :api, defaults: { format: :json } do
-    resources :force_update_app_versions, only: [:index] do
+    resources :force_update_app_versions, only: [:index, :destroy] do
     end
+    put '/api/force_update_app_versions/:id', to: 'force_update_app_versions#update'
+    post 'force_update_app_versions', to: 'force_update_app_versions#create'
+    # The delete route for force_update_app_versions is now included in the resources method above
 
     resources :users_verify_confirmation_token, only: [:create] do
     end
@@ -40,6 +45,7 @@ Rails.application.routes.draw do
       resources :messages, only: %i[index destroy] do
       end
     end
+    # No changes required for the DELETE route within the 'chanels' resource block as it already matches the API endpoint described in the API documentation.
 
     resources :verify_otp, only: [:create] do
     end

--- a/db/migrate/1709006158292_add_new_fields_to_force_update_app_versions.rb
+++ b/db/migrate/1709006158292_add_new_fields_to_force_update_app_versions.rb
@@ -1,0 +1,15 @@
+class AddNewFieldsToForceUpdateAppVersions < ActiveRecord::Migration[6.0]
+  def up
+    add_column :force_update_app_versions, :force_update, :boolean, default: false, null: false
+    add_column :force_update_app_versions, :platform, :string, null: false
+    change_column :force_update_app_versions, :version, :string, limit: 255, null: false
+    change_column :force_update_app_versions, :reason, :text, limit: 65_535
+  end
+
+  def down
+    remove_column :force_update_app_versions, :force_update
+    remove_column :force_update_app_versions, :platform
+    change_column :force_update_app_versions, :version, :string, limit: 255
+    change_column :force_update_app_versions, :reason, :text, limit: 65_535
+  end
+end

--- a/db/migrate/1709009579939_add_chanel_id_to_messages.rb
+++ b/db/migrate/1709009579939_add_chanel_id_to_messages.rb
@@ -1,0 +1,9 @@
+class AddChanelIdToMessages < ActiveRecord::Migration[6.0]
+  def up
+    add_reference :messages, :chanel, foreign_key: true
+  end
+
+  def down
+    remove_reference :messages, :chanel, foreign_key: true
+  end
+end

--- a/db/migrate/1709009579939_add_fields_to_users.rb
+++ b/db/migrate/1709009579939_add_fields_to_users.rb
@@ -1,0 +1,13 @@
+class AddFieldsToUsers < ActiveRecord::Migration[7.0]
+  def up
+    # Add new fields with appropriate data types and constraints
+    # Example for adding a new column:
+    # add_column :users, :new_column_name, :data_type, options
+  end
+
+  def down
+    # Remove the fields that were added in the up method
+    # Example for removing a column:
+    # remove_column :users, :new_column_name
+  end
+end

--- a/lib/exceptions.rb
+++ b/lib/exceptions.rb
@@ -1,5 +1,20 @@
+
 # typed: strict
 module Exceptions
   class AuthenticationError < StandardError; end
   class BadRequest < StandardError; end
+  class RecordNotFound < StandardError; end
+  class ForceUpdateRequired < StandardError; end
+  class ForceUpdateAppVersionNotFound < StandardError; end
+  class InvalidIDFormatError < StandardError; end
+  class InvalidPlatformError < StandardError; end
+  # Resolving the conflict by renaming ForceUpdateBooleanError to ForceUpdateNotBooleanError
+  class ForceUpdateNotBooleanError < StandardError; end
+  class VersionBlankError < StandardError; end
+  class ReasonTooLongError < StandardError; end
+  # Keeping the additional exception from the existing code
+  class InvalidForceUpdateAppVersionIDError < StandardError; end
+  class ChanelNotFoundError < StandardError; end
+  class MessageNotFoundError < StandardError; end
+  class UnauthorizedToDeleteMessageError < StandardError; end
 end

--- a/lib/exceptions.rb
+++ b/lib/exceptions.rb
@@ -1,4 +1,3 @@
-
 # typed: strict
 module Exceptions
   class AuthenticationError < StandardError; end
@@ -8,13 +7,12 @@ module Exceptions
   class ForceUpdateAppVersionNotFound < StandardError; end
   class InvalidIDFormatError < StandardError; end
   class InvalidPlatformError < StandardError; end
-  # Resolving the conflict by renaming ForceUpdateBooleanError to ForceUpdateNotBooleanError
   class ForceUpdateNotBooleanError < StandardError; end
   class VersionBlankError < StandardError; end
   class ReasonTooLongError < StandardError; end
-  # Keeping the additional exception from the existing code
+  class ChannelNotFoundError < StandardError; end
+  class InvalidParameterError < StandardError; end
   class InvalidForceUpdateAppVersionIDError < StandardError; end
-  class ChanelNotFoundError < StandardError; end
   class MessageNotFoundError < StandardError; end
   class UnauthorizedToDeleteMessageError < StandardError; end
 end


### PR DESCRIPTION
This pull request is created by **JITERA**
# Description

#### [API] Delete Channel Message
| file | name |
| --- | --- |
| /config/locales/controller.en.yml | Add localization entries for message deletion success in English |
| /config/locales/controller.ja.yml | Add localization entries for message deletion success in Japanese |
| /app/models/message.rb | Add validation for message belonging to a channel |
| /app/policies/api/chanels/messages_policy.rb | Define authorization logic for message deletion |
| /app/controllers/api/chanels/messages_controller.rb | Implement message deletion logic in MessagesController |
| /config/routes.rb | Ensure the DELETE route for messages is correctly defined |
| /lib/exceptions.rb | Define custom exceptions for message deletion errors |
| /app/controllers/api/base_controller.rb | Add rescue handlers for message deletion exceptions |
------
#### [API] List Channel Messages
| file | name |
| --- | --- |
| /config/locales/app.en.yml | Add translation keys for message listing in English |
| /config/locales/app.ja.yml | Add translation keys for message listing in Japanese |
| /app/models/message.rb | Add validation rules to Message model |
| /config/locales/validation.en.yml | Customize English validation messages for Message model |
| /config/locales/validation.ja.yml | Customize Japanese validation messages for Message model |
| /app/controllers/api/base_controller.rb | Add rescue_from handlers for message listing exceptions |
| /lib/exceptions.rb | Define custom exceptions for message listing |
| /app/controllers/api/chanels/messages_controller.rb | Implement index action in MessagesController |
| /app/services/message_service/index.rb | Update MessageService::Index for message retrieval |
| /app/policies/api/chanels/messages_policy.rb | Define authorization logic in MessagesPolicy |
| /app/views/api/chanels/messages/index.json.jbuilder | Create Jbuilder view for message listing |
| /config/routes.rb | Add route for message listing API endpoint |
------